### PR TITLE
Move to a throws API

### DIFF
--- a/MadogCore.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MadogCore.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cerihughes/provident",
       "state" : {
-        "revision" : "1d65f77cd2242576c6796e9be129e0ac433ff133",
-        "version" : "6.0.0"
+        "revision" : "4b2bfd97332fc9bd305f46e180def1c7d98b1729",
+        "version" : "7.0.0"
       }
     }
   ],

--- a/MadogCore/Container/Container.swift
+++ b/MadogCore/Container/Container.swift
@@ -26,8 +26,7 @@ public protocol Container<T> {
     var presentingContainer: AnyContainer<T>? { get }
     var castValue: AnyContainer<T>? { get }
 
-    @discardableResult
-    func close(animated: Bool, completion: CompletionBlock?) -> Bool
+    func close(animated: Bool, completion: CompletionBlock?) throws
 
     @discardableResult
     func change<VC2, TD2>(
@@ -35,19 +34,12 @@ public protocol Container<T> {
         tokenData: TD2,
         transition: Transition?,
         customisation: CustomisationBlock<VC2>?
-    ) -> AnyContainer<T>? where VC2: ViewController, TD2: TokenData
-}
-
-public protocol TypedContainer<T, VC>: Container where VC: ViewController {
-    associatedtype VC
-
-    var viewController: VC { get }
+    ) throws -> AnyContainer<T> where VC2: ViewController, TD2: TokenData
 }
 
 public extension Container {
-    @discardableResult
-    func close(animated: Bool) -> Bool {
-        close(animated: animated, completion: nil)
+    func close(animated: Bool) throws {
+        try close(animated: animated, completion: nil)
     }
 
     @discardableResult
@@ -56,8 +48,8 @@ public extension Container {
         tokenData: TD2,
         transition: Transition? = nil,
         customisation: CustomisationBlock<VC2>? = nil
-    ) -> AnyContainer<T>? where VC2: ViewController, TD2: TokenData {
-        change(to: identifier, tokenData: tokenData, transition: transition, customisation: customisation)
+    ) throws -> AnyContainer<T> where VC2: ViewController, TD2: TokenData {
+        try change(to: identifier, tokenData: tokenData, transition: transition, customisation: customisation)
     }
 }
 

--- a/MadogCore/Container/ContainerProxy.swift
+++ b/MadogCore/Container/ContainerProxy.swift
@@ -16,8 +16,9 @@ class ContainerProxy<T, TD, VC>: Container where TD: TokenData, VC: ViewControll
     var presentingContainer: AnyContainer<T>? { wrapped?.presentingContainer }
     var castValue: AnyContainer<T>? { wrapped }
 
-    func close(animated: Bool, completion: CompletionBlock?) -> Bool {
-        wrapped?.close(animated: animated, completion: completion) ?? false
+    func close(animated: Bool, completion: CompletionBlock?) throws {
+        guard let wrapped else { throw MadogError<T>.containerReleased }
+        try wrapped.close(animated: animated, completion: completion)
     }
 
     @discardableResult
@@ -26,8 +27,14 @@ class ContainerProxy<T, TD, VC>: Container where TD: TokenData, VC: ViewControll
         tokenData: TD2,
         transition: Transition?,
         customisation: CustomisationBlock<VC2>?
-    ) -> AnyContainer<T>? where VC2: ViewController, TD2: TokenData {
-        wrapped?.change(to: identifier, tokenData: tokenData, transition: transition, customisation: customisation)
+    ) throws -> AnyContainer<T> where VC2: ViewController, TD2: TokenData {
+        guard let wrapped else { throw MadogError<T>.containerReleased }
+        return try wrapped.change(
+            to: identifier,
+            tokenData: tokenData,
+            transition: transition,
+            customisation: customisation
+        )
     }
 }
 

--- a/MadogCore/Container/ContainerProxy.swift
+++ b/MadogCore/Container/ContainerProxy.swift
@@ -37,9 +37,3 @@ class ContainerProxy<T, TD, VC>: Container where TD: TokenData, VC: ViewControll
         )
     }
 }
-
-extension ContainerUI {
-    func proxy() -> AnyContainer<T> {
-        ContainerProxy(wrapped: self)
-    }
-}

--- a/MadogCore/Container/ForwardBackContainer.swift
+++ b/MadogCore/Container/ForwardBackContainer.swift
@@ -12,12 +12,9 @@ public typealias AnyForwardBackContainer<T> = any ForwardBackContainer<T>
 public protocol ForwardBackContainer<T> {
     associatedtype T
 
-    @discardableResult
-    func navigateForward(token: T, animated: Bool) -> Bool
-    @discardableResult
-    func navigateBack(animated: Bool) -> Bool
-    @discardableResult
-    func navigateBackToRoot(animated: Bool) -> Bool
+    func navigateForward(token: T, animated: Bool) throws
+    func navigateBack(animated: Bool) throws
+    func navigateBackToRoot(animated: Bool) throws
 }
 
 public extension Container {

--- a/MadogCore/Container/ModalContainer.swift
+++ b/MadogCore/Container/ModalContainer.swift
@@ -23,11 +23,10 @@ public protocol ModalContainer<T> {
         animated: Bool,
         customisation: CustomisationBlock<VC2>?,
         completion: CompletionBlock?
-    ) -> AnyModalToken<T>? where VC2: ViewController, TD2: TokenData
+    ) throws -> AnyModalToken<T> where VC2: ViewController, TD2: TokenData
     // swiftlint:enable function_parameter_count
 
-    @discardableResult
-    func closeModal(token: AnyModalToken<T>, animated: Bool, completion: CompletionBlock?) -> Bool
+    func closeModal(token: AnyModalToken<T>, animated: Bool, completion: CompletionBlock?) throws
 }
 
 public extension ModalContainer {
@@ -41,8 +40,8 @@ public extension ModalContainer {
         animated: Bool,
         customisation: CustomisationBlock<VC2>? = nil,
         completion: CompletionBlock? = nil
-    ) -> AnyModalToken<T>? where VC2: ViewController, TD2: TokenData {
-        openModal(
+    ) throws -> AnyModalToken<T> where VC2: ViewController, TD2: TokenData {
+        try openModal(
             identifier: identifier,
             tokenData: tokenData,
             presentationStyle: presentationStyle,
@@ -54,9 +53,8 @@ public extension ModalContainer {
         )
     }
 
-    @discardableResult
-    func closeModal(token: AnyModalToken<T>, animated: Bool) -> Bool {
-        closeModal(token: token, animated: animated, completion: nil)
+    func closeModal(token: AnyModalToken<T>, animated: Bool) throws {
+        try closeModal(token: token, animated: animated, completion: nil)
     }
 }
 

--- a/MadogCore/Container/SplitMultiContainer.swift
+++ b/MadogCore/Container/SplitMultiContainer.swift
@@ -10,8 +10,7 @@ public typealias AnySplitMultiContainer<T> = any SplitMultiContainer<T>
 public protocol SplitMultiContainer<T> {
     associatedtype T
 
-    @discardableResult
-    func showDetail(tokens: [T]) -> Bool
+    func showDetail(tokens: [T]) throws
 }
 
 public extension Container {

--- a/MadogCore/Container/SplitSingleContainer.swift
+++ b/MadogCore/Container/SplitSingleContainer.swift
@@ -10,8 +10,7 @@ public typealias AnySplitSingleContainer<T> = any SplitSingleContainer<T>
 public protocol SplitSingleContainer<T> {
     associatedtype T
 
-    @discardableResult
-    func showDetail(token: T) -> Bool
+    func showDetail(token: T) throws
 }
 
 public extension Container {

--- a/MadogCore/ContainerUI/ContainerUI.swift
+++ b/MadogCore/ContainerUI/ContainerUI.swift
@@ -10,9 +10,9 @@ struct IdentifiableToken<T, TD, VC> where TD: TokenData, VC: ViewController {
     let data: TD
 }
 
-typealias AnyContainerDelegate<T> = any ContainerDelegate<T>
+typealias AnyContainerUIDelegate<T> = any ContainerUIDelegate<T>
 
-protocol ContainerDelegate<T>: AnyObject {
+protocol ContainerUIDelegate<T>: AnyObject {
     associatedtype T
 
     func createContainer<VC, TD>(
@@ -39,7 +39,7 @@ open class ContainerUI<T, TD, VC>: Container where TD: TokenData, VC: ViewContro
     public let uuid = UUID()
     public let containerViewController: VC
 
-    weak var delegate: AnyContainerDelegate<T>?
+    weak var delegate: AnyContainerUIDelegate<T>?
 
     public init(containerViewController: VC) {
         self.containerViewController = containerViewController

--- a/MadogCore/ContainerUI/ContainerUI.swift
+++ b/MadogCore/ContainerUI/ContainerUI.swift
@@ -35,7 +35,7 @@ open class ContainerUI<T, TD, VC>: Container where TD: TokenData, VC: ViewContro
         }
     }
 
-    var registry: AnyRegistry<T>?
+    var contentFactory: AnyContainerUIContentFactory<T>?
     public let uuid = UUID()
     public let containerViewController: VC
 
@@ -45,14 +45,12 @@ open class ContainerUI<T, TD, VC>: Container where TD: TokenData, VC: ViewContro
         self.containerViewController = containerViewController
     }
 
-    public func createContentViewController(
-        contentFactory: AnyContainerUIContentFactory<T>,
-        from token: T
-    ) throws -> ViewController {
-        try contentFactory.createContentViewController(from: token, container: self)
+    public func createContentViewController(token: T) throws -> ViewController {
+        guard let contentFactory else { throw MadogError<T>.internalError("ContentFactory not set in \(self)") }
+        return try contentFactory.createContentViewController(token: token, container: self)
     }
 
-    open func populateContainer(contentFactory: AnyContainerUIContentFactory<T>, tokenData: TD) throws {
+    open func populateContainer(tokenData: TD) throws {
         // Override point
     }
 

--- a/MadogCore/ContainerUI/ContainerUI.swift
+++ b/MadogCore/ContainerUI/ContainerUI.swift
@@ -25,7 +25,7 @@ protocol ContainerUIDelegate<T>: AnyObject {
     func releaseContainer(for viewController: ViewController)
 }
 
-open class ContainerUI<T, TD, VC>: Container where TD: TokenData, VC: ViewController {
+open class ContainerUI<T, TD, VC>: InternalContainer where TD: TokenData, VC: ViewController {
 
     public struct Identifier {
         let value: String
@@ -52,6 +52,12 @@ open class ContainerUI<T, TD, VC>: Container where TD: TokenData, VC: ViewContro
 
     open func populateContainer(tokenData: TD) throws {
         // Override point
+    }
+
+    // MARK: - InternalContainer
+
+    func proxy() -> AnyContainer<T> {
+        ContainerProxy(wrapped: self)
     }
 
     // MARK: - Container

--- a/MadogCore/ContainerUI/ContainerUIContentFactory.swift
+++ b/MadogCore/ContainerUI/ContainerUIContentFactory.swift
@@ -5,10 +5,10 @@
 
 import Foundation
 
-public typealias AnyContainerUIContentFactory<T> = any ContainerUIContentFactory<T>
-public protocol ContainerUIContentFactory<T> {
+typealias AnyContainerUIContentFactory<T> = any ContainerUIContentFactory<T>
+protocol ContainerUIContentFactory<T> {
     associatedtype T
-    func createContentViewController<VC, TD>(token: T, container: ContainerUI<T, TD, VC>) throws -> ViewController
+    func createContentViewController(token: T, container: AnyInternalContainer<T>) throws -> ViewController
 }
 
 class ContainerUIContentFactoryImplementation<T>: ContainerUIContentFactory {
@@ -18,10 +18,7 @@ class ContainerUIContentFactoryImplementation<T>: ContainerUIContentFactory {
         self.registry = registry
     }
 
-    public func createContentViewController<VC, TD>(
-        token: T,
-        container: ContainerUI<T, TD, VC>
-    ) throws -> ViewController {
+    public func createContentViewController(token: T, container: AnyInternalContainer<T>) throws -> ViewController {
         try registry.createViewController(token: token, container: container)
     }
 }

--- a/MadogCore/ContainerUI/ContainerUIContentFactory.swift
+++ b/MadogCore/ContainerUI/ContainerUIContentFactory.swift
@@ -8,7 +8,7 @@ import Foundation
 public typealias AnyContainerUIContentFactory<T> = any ContainerUIContentFactory<T>
 public protocol ContainerUIContentFactory<T> {
     associatedtype T
-    func createContentViewController<VC, TD>(from token: T, container: ContainerUI<T, TD, VC>) throws -> ViewController
+    func createContentViewController<VC, TD>(token: T, container: ContainerUI<T, TD, VC>) throws -> ViewController
 }
 
 class ContainerUIContentFactoryImplementation<T>: ContainerUIContentFactory {
@@ -19,7 +19,7 @@ class ContainerUIContentFactoryImplementation<T>: ContainerUIContentFactory {
     }
 
     public func createContentViewController<VC, TD>(
-        from token: T,
+        token: T,
         container: ContainerUI<T, TD, VC>
     ) throws -> ViewController {
         try registry.createViewController(token: token, container: container)

--- a/MadogCore/ContainerUI/ContainerUIContentFactory.swift
+++ b/MadogCore/ContainerUI/ContainerUIContentFactory.swift
@@ -8,7 +8,7 @@ import Foundation
 public typealias AnyContainerUIContentFactory<T> = any ContainerUIContentFactory<T>
 public protocol ContainerUIContentFactory<T> {
     associatedtype T
-    func createContentViewController<VC, TD>(from token: T, container: ContainerUI<T, TD, VC>) -> ViewController?
+    func createContentViewController<VC, TD>(from token: T, container: ContainerUI<T, TD, VC>) throws -> ViewController
 }
 
 class ContainerUIContentFactoryImplementation<T>: ContainerUIContentFactory {
@@ -21,7 +21,7 @@ class ContainerUIContentFactoryImplementation<T>: ContainerUIContentFactory {
     public func createContentViewController<VC, TD>(
         from token: T,
         container: ContainerUI<T, TD, VC>
-    ) -> ViewController? {
-        registry.createViewController(from: token, container: container)
+    ) throws -> ViewController {
+        try registry.createViewController(token: token, container: container)
     }
 }

--- a/MadogCore/ContainerUI/ContainerUIRepository.swift
+++ b/MadogCore/ContainerUI/ContainerUIRepository.swift
@@ -119,14 +119,11 @@ extension ContainerUIFactory {
     func createAndPopulateContainer(
         contentFactory: AnyContainerUIContentFactory<T>,
         tokenData: TD
-    ) -> ContainerUI<T, TD, VC>? {
+    ) throws -> ContainerUI<T, TD, VC> {
         let container = createContainer()
-        do {
-            try container.populateContainer(contentFactory: contentFactory, tokenData: tokenData)
-            return container
-        } catch {
-            return nil
-        }
+        container.contentFactory = contentFactory
+        try container.populateContainer(tokenData: tokenData)
+        return container
     }
 }
 

--- a/MadogCore/ContainerUI/ContainerUIRepository.swift
+++ b/MadogCore/ContainerUI/ContainerUIRepository.swift
@@ -44,27 +44,43 @@ class ContainerUIRepository<T> {
 
     func createContainer<VC, TD>(
         identifiableToken: IdentifiableToken<T, TD, VC>
-    ) -> ContainerUI<T, TD, VC>? where VC: ViewController, TD: TokenData {
+    ) throws -> ContainerUI<T, TD, VC> where VC: ViewController, TD: TokenData {
         let key = identifiableToken.identifier.value
-        if let typed = identifiableToken.typed(SingleUITokenData<T>.self), let factory = singleRegistry[key] {
-            return factory.createContainer(contentFactory: contentFactory, identifiableToken: typed)?.erased()
+        if let typed = identifiableToken.typed(SingleUITokenData<T>.self) {
+            let factory = try singleRegistry.factory(key: key, type: T.self)
+            return try factory.createContainer(contentFactory: contentFactory, identifiableToken: typed).erased()
         }
-        if let typed = identifiableToken.typed(MultiUITokenData<T>.self), let factory = multiRegistry[key] {
-            return factory.createContainer(contentFactory: contentFactory, identifiableToken: typed)?.erased()
+        if let typed = identifiableToken.typed(MultiUITokenData<T>.self) {
+            let factory = try multiRegistry.factory(key: key, type: T.self)
+            return try factory.createContainer(contentFactory: contentFactory, identifiableToken: typed).erased()
         }
-        if let typed = identifiableToken.typed(SplitSingleUITokenData<T>.self), let factory = splitSingleRegistry[key] {
-            return factory.createContainer(contentFactory: contentFactory, identifiableToken: typed)?.erased()
+        if let typed = identifiableToken.typed(SplitSingleUITokenData<T>.self) {
+            let factory = try splitSingleRegistry.factory(key: key, type: T.self)
+            return try factory.createContainer(contentFactory: contentFactory, identifiableToken: typed).erased()
         }
-        if let typed = identifiableToken.typed(SplitMultiUITokenData<T>.self), let factory = splitMultiRegistry[key] {
-            return factory.createContainer(contentFactory: contentFactory, identifiableToken: typed)?.erased()
+        if let typed = identifiableToken.typed(SplitMultiUITokenData<T>.self) {
+            let factory = try splitMultiRegistry.factory(key: key, type: T.self)
+            return try factory.createContainer(contentFactory: contentFactory, identifiableToken: typed).erased()
         }
-        return nil
+        throw MadogError<T>.internalError("Unknown TokenData type")
+    }
+}
+
+private extension Dictionary where Key == String {
+    func factory<T>(key: String, type: T.Type) throws -> Value {
+        guard let value = self[key] else {
+            throw MadogError<T>.noMatchingContainer(key)
+        }
+        return value
     }
 }
 
 private extension ContainerUI {
-    func erased<T2, TD2, VC2>() -> ContainerUI<T2, TD2, VC2>? {
-        self as? ContainerUI<T2, TD2, VC2>
+    func erased<T2, TD2, VC2>() throws -> ContainerUI<T2, TD2, VC2> {
+        guard let erased = self as? ContainerUI<T2, TD2, VC2> else {
+            throw MadogError<T>.internalError("Cannot erase \(self) to correct ContainerUI")
+        }
+        return erased
     }
 }
 
@@ -74,7 +90,7 @@ typealias SplitSingleContainerUIFactoryWrapper<T> = ContainerUIFactoryWrapper<T,
 typealias SplitMultiContainerUIFactoryWrapper<T> = ContainerUIFactoryWrapper<T, SplitMultiUITokenData<T>>
 
 struct ContainerUIFactoryWrapper<T, TD> where TD: TokenData {
-    typealias Closure = (AnyContainerUIContentFactory<T>, TD) -> Any?
+    typealias Closure = (AnyContainerUIContentFactory<T>, TD) throws -> Any
 
     private let closure: Closure
 
@@ -85,8 +101,11 @@ struct ContainerUIFactoryWrapper<T, TD> where TD: TokenData {
     func createContainer<VC>(
         contentFactory: AnyContainerUIContentFactory<T>,
         identifiableToken: IdentifiableToken<T, TD, VC>
-    ) -> ContainerUI<T, TD, VC>? {
-        closure(contentFactory, identifiableToken.data) as? ContainerUI<T, TD, VC>
+    ) throws -> ContainerUI<T, TD, VC> {
+        guard let container = try closure(contentFactory, identifiableToken.data) as? ContainerUI<T, TD, VC> else {
+            throw MadogError<T>.internalError("ContentFactory doesn't create ContainerUI")
+        }
+        return container
     }
 }
 

--- a/MadogCore/ContainerUI/InternalContainer.swift
+++ b/MadogCore/ContainerUI/InternalContainer.swift
@@ -1,0 +1,11 @@
+//
+//  Created by Ceri Hughes on 20/11/2023.
+//  Copyright © 2023 Ceri Hughes. All rights reserved.
+//
+import Foundation
+
+typealias AnyInternalContainer<T> = any InternalContainer<T>
+
+protocol InternalContainer<T>: AnyObject, Container {
+    func proxy() -> AnyContainer<T>
+}

--- a/MadogCore/ContainerUI/NavigatingContainerUI.swift
+++ b/MadogCore/ContainerUI/NavigatingContainerUI.swift
@@ -8,20 +8,10 @@
 import Foundation
 
 open class NavigatingContainerUI<T>: ContainerUI<T, SingleUITokenData<T>, NavigationController>, ForwardBackContainer {
-    private var contentFactory: AnyContainerUIContentFactory<T>?
-
-    override open func populateContainer(
-        contentFactory: AnyContainerUIContentFactory<T>,
-        tokenData: SingleUITokenData<T>
-    ) throws {
-        self.contentFactory = contentFactory
-    }
-
     // MARK: - ForwardBackContainer
 
     public func navigateForward(token: T, animated: Bool) throws {
-        guard let contentFactory else { throw MadogError<T>.internalError("ContentFactory not set in \(self)") }
-        let toViewController = try createContentViewController(contentFactory: contentFactory, from: token)
+        let toViewController = try createContentViewController(token: token)
         containerViewController.pushViewController(toViewController, animated: animated)
     }
 

--- a/MadogCore/ContainerUI/NavigatingContainerUI.swift
+++ b/MadogCore/ContainerUI/NavigatingContainerUI.swift
@@ -19,22 +19,24 @@ open class NavigatingContainerUI<T>: ContainerUI<T, SingleUITokenData<T>, Naviga
 
     // MARK: - ForwardBackContainer
 
-    public func navigateForward(token: T, animated: Bool) -> Bool {
-        guard
-            let contentFactory,
-            let toViewController = try? createContentViewController(contentFactory: contentFactory, from: token)
-        else { return false }
-
+    public func navigateForward(token: T, animated: Bool) throws {
+        guard let contentFactory else { throw MadogError<T>.internalError("ContentFactory not set in \(self)") }
+        let toViewController = try createContentViewController(contentFactory: contentFactory, from: token)
         containerViewController.pushViewController(toViewController, animated: animated)
-        return true
     }
 
-    public func navigateBack(animated: Bool) -> Bool {
-        containerViewController.popViewController(animated: animated) != nil
+    public func navigateBack(animated: Bool) throws {
+        let popped = containerViewController.popViewController(animated: animated)
+        if popped == nil {
+            throw MadogError<T>.cannotNavigateBack
+        }
     }
 
-    public func navigateBackToRoot(animated _: Bool) -> Bool {
-        containerViewController.popToRootViewController(animated: true) != nil
+    public func navigateBackToRoot(animated _: Bool) throws {
+        let popped = containerViewController.popToRootViewController(animated: true)
+        if popped == nil {
+            throw MadogError<T>.cannotNavigateBack
+        }
     }
 }
 

--- a/MadogCore/Madog.swift
+++ b/MadogCore/Madog.swift
@@ -62,13 +62,12 @@ public final class Madog<T>: ContainerDelegate {
         in window: Window,
         transition: Transition? = nil,
         customisation: CustomisationBlock<VC>? = nil
-    ) -> AnyContainer<T>? where VC: ViewController, TD: TokenData {
-        guard let container = createContainer(
+    ) throws -> AnyContainer<T> where VC: ViewController, TD: TokenData {
+        let container = try createContainer(
             identifiableToken: .init(identifier: identifier, data: tokenData),
             isModal: false,
             customisation: customisation
-        ) else { return nil }
-
+        )
         window.setRootViewController(container.containerViewController, transition: transition)
         return container.proxy()
     }
@@ -87,11 +86,8 @@ public final class Madog<T>: ContainerDelegate {
         identifiableToken: IdentifiableToken<T, TD, VC>,
         isModal: Bool,
         customisation: CustomisationBlock<VC>?
-    ) -> ContainerUI<T, TD, VC>? where VC: ViewController, TD: TokenData {
-        guard let container = containerRepository.createContainer(identifiableToken: identifiableToken) else {
-            return nil
-        }
-
+    ) throws -> ContainerUI<T, TD, VC> where VC: ViewController, TD: TokenData {
+        let container = try containerRepository.createContainer(identifiableToken: identifiableToken)
         let containerViewController = container.containerViewController
         container.delegate = self
         persist(container: container, containerViewController: containerViewController, isModal: isModal)

--- a/MadogCore/Madog.swift
+++ b/MadogCore/Madog.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public final class Madog<T>: ContainerDelegate {
+public final class Madog<T>: ContainerUIDelegate {
     private let registrar = Registrar<T>()
     private let contentFactory: AnyContainerUIContentFactory<T>
     private let containerRepository: ContainerUIRepository<T>

--- a/MadogCore/ProvidentBridge/Registry.swift
+++ b/MadogCore/ProvidentBridge/Registry.swift
@@ -11,7 +11,7 @@ public typealias AnyRegistry<T> = any Registry<T>
 public protocol Registry<T>: AnyObject {
     associatedtype T
 
-    func createViewController<VC, TD>(token: T, container: ContainerUI<T, TD, VC>) throws -> ViewController
+    func createViewController(token: T, container: AnyContainer<T>) throws -> ViewController
 }
 
 public enum MadogError<T>: Error {
@@ -30,7 +30,10 @@ class RegistryBridge<T>: Registry {
         self.bridged = bridged
     }
 
-    func createViewController<VC, TD>(token: T, container: ContainerUI<T, TD, VC>) throws -> ViewController {
+    func createViewController(token: T, container: AnyContainer<T>) throws -> ViewController {
+        guard let container = container as? AnyInternalContainer<T> else {
+            throw MadogError<T>.internalError("Container is not correct type (AnyInternalContainer)")
+        }
         do {
             return try bridged.createViewController(token: token, context: container.proxy())
         } catch ProvidentError<T>.noMatchingViewController(let token) {

--- a/MadogCore/ProvidentBridge/Registry.swift
+++ b/MadogCore/ProvidentBridge/Registry.swift
@@ -11,7 +11,16 @@ public typealias AnyRegistry<T> = any Registry<T>
 public protocol Registry<T>: AnyObject {
     associatedtype T
 
-    func createViewController<VC, TD>(from token: T, container: ContainerUI<T, TD, VC>) -> ViewController?
+    func createViewController<VC, TD>(token: T, container: ContainerUI<T, TD, VC>) throws -> ViewController
+}
+
+public enum MadogError<T>: Error {
+    case noMatchingViewController(T)
+    case noMatchingContainer(String)
+    case internalError(String)
+    case containerReleased
+    case containerHasNoWindow
+    case cannotNavigateBack
 }
 
 class RegistryBridge<T>: Registry {
@@ -21,8 +30,14 @@ class RegistryBridge<T>: Registry {
         self.bridged = bridged
     }
 
-    func createViewController<VC, TD>(from token: T, container: ContainerUI<T, TD, VC>) -> ViewController? {
-        bridged.createViewController(from: token, context: container.proxy())
+    func createViewController<VC, TD>(token: T, container: ContainerUI<T, TD, VC>) throws -> ViewController {
+        do {
+            return try bridged.createViewController(token: token, context: container.proxy())
+        } catch ProvidentError<T>.noMatchingViewController(let token) {
+            throw MadogError<T>.noMatchingViewController(token)
+        } catch {
+            throw MadogError<T>.internalError("Unexpected Provident error")
+        }
     }
 }
 

--- a/MadogCoreKIFTests/ContainerUI/ContainerUITests.swift
+++ b/MadogCoreKIFTests/ContainerUI/ContainerUITests.swift
@@ -12,37 +12,37 @@ import XCTest
 @testable import MadogCore
 
 class ContainerUITests: MadogKIFTestCase {
-    func testCloseReleasesMainContainer() {
-        let container = renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
+    func testCloseReleasesMainContainer() throws {
+        let container = try renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
         waitForLabel(token: "vc1")
         XCTAssertNotNil(container.castValue)
 
-        closeContainerAndWait(container)
+        try closeContainerAndWait(container)
         XCTAssertNil(container.castValue)
     }
 
-    func testCloseModalReleasesModalContainer() {
-        let container = renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
+    func testCloseModalReleasesModalContainer() throws {
+        let container = try renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
         waitForLabel(token: "vc1")
         XCTAssertNotNil(container.castValue)
 
-        let modalContainer = createModalContainer(container: container, token: "vc2")
+        let modalContainer = try createModalContainer(container: container, token: "vc2")
         XCTAssertNotNil(modalContainer.castValue)
 
-        closeContainerAndWait(modalContainer)
+        try closeContainerAndWait(modalContainer)
         XCTAssertNotNil(container.castValue)
         XCTAssertNil(modalContainer.castValue)
     }
 
-    func testCloseMainReleasesBothContainers() {
-        let container = renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
+    func testCloseMainReleasesBothContainers() throws {
+        let container = try renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
         waitForLabel(token: "vc1")
         XCTAssertNotNil(container.castValue)
 
-        let modalContainer = createModalContainer(container: container, token: "vc2")
+        let modalContainer = try createModalContainer(container: container, token: "vc2")
         XCTAssertNotNil(modalContainer.castValue)
 
-        closeContainerAndWait(container)
+        try closeContainerAndWait(container)
 
         XCTAssertNil(container.castValue)
         XCTAssertNil(modalContainer.castValue)
@@ -50,20 +50,20 @@ class ContainerUITests: MadogKIFTestCase {
         waitForAbsenceOfLabel(token: "vc2")
     }
 
-    func testCloseWithNestedContainers() {
-        let container = renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
+    func testCloseWithNestedContainers() throws {
+        let container = try renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
         waitForLabel(token: "vc1")
 
-        let modalContainer1 = createModalContainer(container: container, token: "vc2")
+        let modalContainer1 = try createModalContainer(container: container, token: "vc2")
         XCTAssertNotNil(modalContainer1.castValue)
 
-        let modalContainer2 = createModalContainer(container: modalContainer1, token: "vc3")
+        let modalContainer2 = try createModalContainer(container: modalContainer1, token: "vc3")
         XCTAssertNotNil(modalContainer2.castValue)
 
-        let modalContainer3 = createModalContainer(container: modalContainer2, token: "vc4")
+        let modalContainer3 = try createModalContainer(container: modalContainer2, token: "vc4")
         XCTAssertNotNil(modalContainer3.castValue)
 
-        XCTAssertTrue(closeContainerAndWait(modalContainer2)) // Closes modals vc3 and vc4
+        XCTAssertNoThrow(try closeContainerAndWait(modalContainer2)) // Closes modals vc3 and vc4
 
         XCTAssertNotNil(container.castValue)
         XCTAssertNotNil(modalContainer1.castValue)
@@ -73,7 +73,7 @@ class ContainerUITests: MadogKIFTestCase {
         waitForAbsenceOfLabel(token: "vc3")
         waitForAbsenceOfLabel(token: "vc4")
 
-        closeContainerAndWait(container) // Closes main and modal 1
+        try closeContainerAndWait(container) // Closes main and modal 1
 
         XCTAssertNil(container.castValue)
         XCTAssertNil(modalContainer1.castValue)
@@ -81,20 +81,20 @@ class ContainerUITests: MadogKIFTestCase {
         waitForAbsenceOfLabel(token: "vc2")
     }
 
-    func testChangeReleasesOldModalContainers() {
-        let container1 = renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
+    func testChangeReleasesOldModalContainers() throws {
+        let container1 = try renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
         waitForLabel(token: "vc1")
         XCTAssertNotNil(container1.castValue)
 
-        let modalContainer1 = createModalContainer(container: container1, token: "vc2")
+        let modalContainer1 = try createModalContainer(container: container1, token: "vc2")
         waitForLabel(token: "vc2")
         XCTAssertNotNil(modalContainer1.castValue)
 
-        let modalContainer2 = createModalContainer(container: modalContainer1, token: "vc3")
+        let modalContainer2 = try createModalContainer(container: modalContainer1, token: "vc3")
         waitForLabel(token: "vc3")
         XCTAssertNotNil(modalContainer2.castValue)
 
-        let container2 = container1.change(to: .test(), tokenData: .single("vc4"))!
+        let container2 = try container1.change(to: .test(), tokenData: .single("vc4"))
         waitForLabel(token: "vc4")
 
         XCTAssertNil(container1.castValue)
@@ -103,56 +103,56 @@ class ContainerUITests: MadogKIFTestCase {
         XCTAssertNotNil(container2.castValue)
     }
 
-    func testOpenSingleUIModal() {
-        let container = renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
+    func testOpenSingleUIModal() throws {
+        let container = try renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
         waitForLabel(token: "vc1")
         XCTAssertNotNil(container.castValue)
 
-        let modalContainer = createModalContainer(container: container, token: "vc2")
+        let modalContainer = try createModalContainer(container: container, token: "vc2")
         waitForLabel(token: "vc2")
         XCTAssertNotNil(modalContainer.castValue)
     }
 
-    func testCloseSingleUIModal() {
-        let container = renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
+    func testCloseSingleUIModal() throws {
+        let container = try renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
         waitForLabel(token: "vc1")
         XCTAssertNotNil(container.castValue)
 
-        let modalToken = createModal(container: container, token: "vc2")
+        let modalToken = try createModal(container: container, token: "vc2")
         XCTAssertNotNil(modalToken)
 
-        XCTAssertTrue(closeModalAndWait(container.modal!, token: modalToken))
+        XCTAssertNoThrow(try closeModalAndWait(container.modal!, token: modalToken))
         waitForAbsenceOfTitle(token: "vc2")
     }
 
-    func testOpenModalCompletionIsFired() {
-        let container = renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
+    func testOpenModalCompletionIsFired() throws {
+        let container = try renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
 
         let completionExpectation = expectation(description: "Modal opened")
-        let modalToken = openModalAndWait(container.modal!, identifier: .test(), tokenData: .single("vc2")) {
+        let modalToken = try openModalAndWait(container.modal!, identifier: .test(), tokenData: .single("vc2")) {
             completionExpectation.fulfill()
         }
         XCTAssertNotNil(modalToken.container.castValue)
         waitForExpectations(timeout: 10)
     }
 
-    func testCloseModalCompletionIsFired() {
-        let container = renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
+    func testCloseModalCompletionIsFired() throws {
+        let container = try renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
 
-        let modalToken = openModalAndWait(container.modal!, identifier: .test(), tokenData: .single("vc2"))
+        let modalToken = try openModalAndWait(container.modal!, identifier: .test(), tokenData: .single("vc2"))
         XCTAssertNotNil(modalToken)
         waitForLabel(token: "vc2")
 
         let completionExpectation = expectation(description: "Modal closed")
-        closeModalAndWait(container.modal!, token: modalToken) { completionExpectation.fulfill() }
+        try closeModalAndWait(container.modal!, token: modalToken) { completionExpectation.fulfill() }
         waitForExpectations(timeout: 10)
     }
 
-    func testCloseCompletionIsFired() {
-        let container = renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
+    func testCloseCompletionIsFired() throws {
+        let container = try renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
 
         let openExpectation = expectation(description: "Modal opened")
-        let modalToken = openModalAndWait(container.modal!, identifier: .test(), tokenData: .single("vc2")) {
+        let modalToken = try openModalAndWait(container.modal!, identifier: .test(), tokenData: .single("vc2")) {
             openExpectation.fulfill()
         }
         wait(for: [openExpectation], timeout: 10)
@@ -160,23 +160,23 @@ class ContainerUITests: MadogKIFTestCase {
         let modalContainer = modalToken.container
         let closeExpectation = expectation(description: "Container closed")
 
-        closeContainerAndWait(modalContainer) { closeExpectation.fulfill() }
+        try closeContainerAndWait(modalContainer) { closeExpectation.fulfill() }
         waitForExpectations(timeout: 10)
     }
 
-    func testPresentingContainer() {
-        let container = renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
+    func testPresentingContainer() throws {
+        let container = try renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
         XCTAssertNil(container.presentingContainer)
 
         let openExpectation1 = expectation(description: "Modal 1 opened")
-        var modalToken = openModalAndWait(container.modal!, identifier: .test(), tokenData: .single("vc2")) {
+        var modalToken = try openModalAndWait(container.modal!, identifier: .test(), tokenData: .single("vc2")) {
             openExpectation1.fulfill()
         }
         wait(for: [openExpectation1], timeout: 10)
         let modalContainer1 = modalToken.container
 
         let openExpectation2 = expectation(description: "Modal 2 opened")
-        modalToken = openModalAndWait(modalContainer1.modal!, identifier: .test(), tokenData: .single("vc3")) {
+        modalToken = try openModalAndWait(modalContainer1.modal!, identifier: .test(), tokenData: .single("vc3")) {
             openExpectation2.fulfill()
         }
         wait(for: [openExpectation2], timeout: 10)
@@ -189,9 +189,9 @@ class ContainerUITests: MadogKIFTestCase {
     private func createModal(
         container: AnyContainer<String>,
         token: String
-    ) -> AnyModalToken<String> {
+    ) throws -> AnyModalToken<String> {
         let openExpectation = expectation(description: "Modal \(token) opened")
-        let modalToken = openModalAndWait(container.modal!, identifier: .test(), tokenData: .single(token)) {
+        let modalToken = try openModalAndWait(container.modal!, identifier: .test(), tokenData: .single(token)) {
             openExpectation.fulfill()
         }
         wait(for: [openExpectation], timeout: 10)
@@ -199,8 +199,8 @@ class ContainerUITests: MadogKIFTestCase {
         return modalToken
     }
 
-    private func createModalContainer(container: AnyContainer<String>, token: String) -> AnyContainer<String> {
-        createModal(container: container, token: token).container
+    private func createModalContainer(container: AnyContainer<String>, token: String) throws -> AnyContainer<String> {
+        try createModal(container: container, token: token).container
     }
 }
 

--- a/MadogCoreKIFTests/ContainerUI/CustomisationTests.swift
+++ b/MadogCoreKIFTests/ContainerUI/CustomisationTests.swift
@@ -12,22 +12,21 @@ import XCTest
 @testable import MadogCore
 
 class CustomisationTests: MadogKIFTestCase {
-    func testMainCustomisationBlock() {
-        let container = renderUIAndWait(
+    func testMainCustomisationBlock() throws {
+        _ = try renderUIAndWait(
             identifier: .test(),
             tokenData: .single("vc1"),
             customisation: customise(viewController:)
         )
 
-        XCTAssertNotNil(container)
         waitForTitle(token: "CUSTOMISED")
     }
 
     func testModalCustomisationBlock() throws {
-        let container = try XCTUnwrap(renderUIAndWait(identifier: .test(), tokenData: .single("vc1")))
+        let container = try renderUIAndWait(identifier: .test(), tokenData: .single("vc1"))
 
         waitForAbsenceOfTitle(token: "CUSTOMISED")
-        let token = container.modal?.openModal(
+        let token = try container.modal?.openModal(
             identifier: .test(),
             tokenData: .single("vc1"),
             animated: true,

--- a/MadogCoreTestContainers/TestContainerUI_AppKit.swift
+++ b/MadogCoreTestContainers/TestContainerUI_AppKit.swift
@@ -9,13 +9,10 @@ import MadogCore
 import AppKit
 
 class TestContainerUI<T>: ContainerUI<T, SingleUITokenData<T>, ViewController> {
-    override func populateContainer(
-        contentFactory: AnyContainerUIContentFactory<T>,
-        tokenData: SingleUITokenData<T>
-    ) throws {
-        try super.populateContainer(contentFactory: contentFactory, tokenData: tokenData)
+    override func populateContainer(tokenData: SingleUITokenData<T>) throws {
+        try super.populateContainer(tokenData: tokenData)
 
-        let vc = try createContentViewController(contentFactory: contentFactory, from: tokenData.token)
+        let vc = try createContentViewController(token: tokenData.token)
 
         containerViewController.addChild(vc)
         containerViewController.view.addSubview(vc.view)

--- a/MadogCoreTestContainers/TestContainerUI_UIKit.swift
+++ b/MadogCoreTestContainers/TestContainerUI_UIKit.swift
@@ -9,13 +9,10 @@ import MadogCore
 import UIKit
 
 class TestContainerUI<T>: ContainerUI<T, SingleUITokenData<T>, ViewController> {
-    override func populateContainer(
-        contentFactory: AnyContainerUIContentFactory<T>,
-        tokenData: SingleUITokenData<T>
-    ) throws {
-        try super.populateContainer(contentFactory: contentFactory, tokenData: tokenData)
+    override func populateContainer(tokenData: SingleUITokenData<T>) throws {
+        try super.populateContainer(tokenData: tokenData)
 
-        let vc = try createContentViewController(contentFactory: contentFactory, from: tokenData.token)
+        let vc = try createContentViewController(token: tokenData.token)
 
         vc.willMove(toParent: containerViewController)
 

--- a/MadogCoreTestContainers/TestNavigatingContainerUI_UIKit.swift
+++ b/MadogCoreTestContainers/TestNavigatingContainerUI_UIKit.swift
@@ -9,13 +9,10 @@ import MadogCore
 import UIKit
 
 class TestNavigatingContainerUI<T>: NavigatingContainerUI<T> {
-    override func populateContainer(
-        contentFactory: AnyContainerUIContentFactory<T>,
-        tokenData: SingleUITokenData<T>
-    ) throws {
-        try super.populateContainer(contentFactory: contentFactory, tokenData: tokenData)
+    override func populateContainer(tokenData: SingleUITokenData<T>) throws {
+        try super.populateContainer(tokenData: tokenData)
 
-        let viewController = try createContentViewController(contentFactory: contentFactory, from: tokenData.token)
+        let viewController = try createContentViewController(token: tokenData.token)
         containerViewController.setViewControllers([viewController], animated: false)
     }
 }

--- a/MadogCoreTestContainers/TestTabBarContainerUI.swift
+++ b/MadogCoreTestContainers/TestTabBarContainerUI.swift
@@ -11,14 +11,11 @@ import UIKit
 class TestTabBarContainerUI<T>: ContainerUI<T, MultiUITokenData<T>, UITabBarController>, MultiContainer {
     private let tabBarController = UITabBarController()
 
-    override func populateContainer(
-        contentFactory: AnyContainerUIContentFactory<T>,
-        tokenData: MultiUITokenData<T>
-    ) throws {
-        try super.populateContainer(contentFactory: contentFactory, tokenData: tokenData)
+    override func populateContainer(tokenData: MultiUITokenData<T>) throws {
+        try super.populateContainer(tokenData: tokenData)
 
         let viewControllers = try tokenData.tokens.compactMap {
-            try createContentViewController(contentFactory: contentFactory, from: $0)
+            try createContentViewController(token: $0)
         }
 
         tabBarController.viewControllers = viewControllers

--- a/MadogCoreTestUtilities/MadogCUT.swift
+++ b/MadogCoreTestUtilities/MadogCUT.swift
@@ -20,22 +20,20 @@ public extension MadogCUT {
         identifier: ContainerUI<T, TD, VC>.Identifier,
         tokenData: TD,
         customisation: CustomisationBlock<VC>? = nil
-    ) -> AnyContainer<T> where VC: ViewController, TD: TokenData {
-        let result = madog.renderUI(
+    ) throws -> AnyContainer<T> where VC: ViewController, TD: TokenData {
+        let result = try madog.renderUI(
             identifier: identifier,
             tokenData: tokenData,
             in: window,
             customisation: customisation
         )
         waitForAnimationsToFinish()
-        return result!
+        return result
     }
 
-    @discardableResult
-    func closeContainerAndWait(_ container: AnyContainer<T>, completion: CompletionBlock? = nil) -> Bool {
-        let result = container.close(animated: true, completion: completion)
+    func closeContainerAndWait(_ container: AnyContainer<T>, completion: CompletionBlock? = nil) throws {
+        try container.close(animated: true, completion: completion)
         waitForAnimationsToFinish()
-        return result
     }
 
     func openModalAndWait<VC, TD2>(
@@ -43,8 +41,8 @@ public extension MadogCUT {
         identifier: ContainerUI<T, TD2, VC>.Identifier,
         tokenData: TD2,
         completion: CompletionBlock? = nil
-    ) -> AnyModalToken<T> where VC: UIViewController, TD2: TokenData {
-        let result = modalContainer.openModal(
+    ) throws -> AnyModalToken<T> where VC: UIViewController, TD2: TokenData {
+        let result = try modalContainer.openModal(
             identifier: identifier,
             tokenData: tokenData,
             presentationStyle: .formSheet,
@@ -52,18 +50,16 @@ public extension MadogCUT {
             completion: completion
         )
         waitForAnimationsToFinish()
-        return result!
+        return result
     }
 
-    @discardableResult
     func closeModalAndWait(
         _ modalContainer: AnyModalContainer<T>,
         token: AnyModalToken<T>,
         completion: CompletionBlock? = nil
-    ) -> Bool {
-        let result = modalContainer.closeModal(token: token, animated: true, completion: completion)
+    ) throws {
+        try modalContainer.closeModal(token: token, animated: true, completion: completion)
         waitForAnimationsToFinish()
-        return result
     }
 
     private func waitForAnimationsToFinish(_ file: String = #file, _ line: Int = #line) {

--- a/MadogCoreTests/MadogTests.swift
+++ b/MadogCoreTests/MadogTests.swift
@@ -44,11 +44,11 @@ class MadogTests: XCTestCase {
 
         weak var impl1: TestContainerUI<Int>?
         try autoreleasepool {
-            impl1 = try madog.renderUI(identifier: .test(), tokenData: .single(0), in: window)?.asImpl()
+            impl1 = try madog.renderUI(identifier: .test(), tokenData: .single(0), in: window).asImpl()
             XCTAssertNotNil(impl1)
         }
 
-        weak var impl2 = try madog.renderUI(identifier: .test(), tokenData: .single(1), in: window)?.asImpl()
+        weak var impl2 = try madog.renderUI(identifier: .test(), tokenData: .single(1), in: window).asImpl()
         XCTAssertNil(impl1)
         XCTAssertNotNil(impl2)
     }
@@ -58,7 +58,7 @@ class MadogTests: XCTestCase {
         let tracker = DeallocationTracker()
 
         try autoreleasepool {
-            weak var impl = try madog.renderUI(identifier: .test(), tokenData: .single(0), in: window)?.asImpl()
+            weak var impl = try madog.renderUI(identifier: .test(), tokenData: .single(0), in: window).asImpl()
             XCTAssertNotNil(impl)
             try impl?.assignDelegate(tracker)
         }
@@ -66,7 +66,7 @@ class MadogTests: XCTestCase {
         XCTAssertEqual(tracker.deallocations, 0)
 
         try autoreleasepool {
-            weak var impl = try madog.renderUI(identifier: .test(), tokenData: .single(0), in: window)?.asImpl()
+            weak var impl = try madog.renderUI(identifier: .test(), tokenData: .single(0), in: window).asImpl()
             XCTAssertNotNil(impl)
             try impl?.assignDelegate(tracker)
         }
@@ -74,7 +74,7 @@ class MadogTests: XCTestCase {
         XCTAssertEqual(tracker.deallocations, 1)
 
         try autoreleasepool {
-            weak var impl = try madog.renderUI(identifier: .test(), tokenData: .single(0), in: window)?.asImpl()
+            weak var impl = try madog.renderUI(identifier: .test(), tokenData: .single(0), in: window).asImpl()
             XCTAssertNotNil(impl)
             try impl?.assignDelegate(tracker)
         }
@@ -102,7 +102,7 @@ class MadogTests: XCTestCase {
 
         let identifier = ContainerUI<Int, TD, VC>.Identifier("testSingleTokenFactory")
         XCTAssertTrue(madog.addContainerUIFactory(identifier: identifier, factory: TestFactory()))
-        XCTAssertNotNil(madog.renderUI(identifier: identifier, tokenData: .single(1), in: Window()))
+        XCTAssertNoThrow(try madog.renderUI(identifier: identifier, tokenData: .single(1), in: Window()))
     }
 
     func testMultiTokenFactory() {
@@ -117,7 +117,7 @@ class MadogTests: XCTestCase {
 
         let identifier = ContainerUI<Int, TD, VC>.Identifier("testMultiTokenFactory")
         XCTAssertTrue(madog.addContainerUIFactory(identifier: identifier, factory: TestFactory()))
-        XCTAssertNotNil(madog.renderUI(identifier: identifier, tokenData: .multi(1, 2, 3), in: Window()))
+        XCTAssertNoThrow(try madog.renderUI(identifier: identifier, tokenData: .multi(1, 2, 3), in: Window()))
     }
 
     func testSplitSingleTokenFactory() {
@@ -132,7 +132,7 @@ class MadogTests: XCTestCase {
 
         let identifier = ContainerUI<Int, TD, VC>.Identifier("testSingleTokenFactory")
         XCTAssertTrue(madog.addContainerUIFactory(identifier: identifier, factory: TestFactory()))
-        XCTAssertNotNil(madog.renderUI(identifier: identifier, tokenData: .splitSingle(1, 2), in: Window()))
+        XCTAssertNoThrow(try madog.renderUI(identifier: identifier, tokenData: .splitSingle(1, 2), in: Window()))
     }
 
     func testSplitMultiTokenFactory() {
@@ -147,7 +147,7 @@ class MadogTests: XCTestCase {
 
         let identifier = ContainerUI<Int, TD, VC>.Identifier("testMultiTokenFactory")
         XCTAssertTrue(madog.addContainerUIFactory(identifier: identifier, factory: TestFactory()))
-        XCTAssertNotNil(madog.renderUI(identifier: identifier, tokenData: .splitMulti(1, [2, 3]), in: Window()))
+        XCTAssertNoThrow(try madog.renderUI(identifier: identifier, tokenData: .splitMulti(1, [2, 3]), in: Window()))
     }
 }
 

--- a/MadogCoreTests/MadogTests.swift
+++ b/MadogCoreTests/MadogTests.swift
@@ -39,6 +39,42 @@ class MadogTests: XCTestCase {
         super.tearDown()
     }
 
+    func testContainerErrorIsThrown() {
+        let fakeIdentifier = ContainerUI<Int, SingleUITokenData<Int>, ViewController>.Identifier("fakeIdentifier")
+
+        do {
+            try _ = madog.renderUI(identifier: fakeIdentifier, tokenData: .single(0), in: Window())
+            XCTFail("Expecting an error to be thrown")
+        } catch MadogError<Int>.noMatchingContainer(let identifier) {
+            XCTAssertEqual(identifier, "fakeIdentifier")
+        } catch {
+            XCTFail("Expecting a different error to be thrown")
+        }
+    }
+
+    func testContainerErrorIsThrown_notConfigured() {
+        madog = Madog() // recreate so no resolver has run
+        do {
+            try _ = madog.renderUI(identifier: .test(), tokenData: .single(0), in: Window())
+            XCTFail("Expecting an error to be thrown")
+        } catch MadogError<Int>.noMatchingContainer(let identifier) {
+            XCTAssertEqual(identifier, "testIdentifier")
+        } catch {
+            XCTFail("Expecting a different error to be thrown")
+        }
+    }
+
+    func testViewControllerErrorIsThrown() throws {
+        do {
+            try _ = madog.renderUI(identifier: .test(), tokenData: .single(-1), in: Window())
+            XCTFail("Expecting an error to be thrown")
+        } catch MadogError<Int>.noMatchingViewController(let token) {
+            XCTAssertEqual(token, -1)
+        } catch {
+            XCTFail("Expecting a different error to be thrown")
+        }
+    }
+
     func testMadogKeepsStrongReferenceToCurrentContainer() throws {
         let window = Window()
 

--- a/MadogCoreTests/MadogTypesTests.swift
+++ b/MadogCoreTests/MadogTypesTests.swift
@@ -36,9 +36,9 @@ class MadogTypesTests: XCTestCase {
 
         let container = NavigatingContainerUI<Int>(containerViewController: UINavigationController())
 
-        XCTAssertNil(registry.createViewController(from: 1, container: container))
+        XCTAssertThrowsError(try registry.createViewController(token: 1, container: container))
         registrar.resolve(resolver: resolver)
-        XCTAssertNotNil(registry.createViewController(from: 0, container: container))
+        XCTAssertNoThrow(try registry.createViewController(token: 0, container: container))
     }
 }
 

--- a/MadogCoreTests/TestTypes.swift
+++ b/MadogCoreTests/TestTypes.swift
@@ -19,7 +19,7 @@ class TestResolver: Resolver {
 
 class TestViewControllerProvider: ViewControllerProvider {
     func createViewController(token: Int, container: AnyContainer<Int>) -> ViewController? {
-        TestViewController(container: container)
+        token >= 0 ? TestViewController(container: container) : nil
     }
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cerihughes/provident",
       "state" : {
-        "revision" : "1d65f77cd2242576c6796e9be129e0ac433ff133",
-        "version" : "6.0.0"
+        "revision" : "4b2bfd97332fc9bd305f46e180def1c7d98b1729",
+        "version" : "7.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "MadogCoreTestUtilities", targets: ["MadogCoreTestUtilities"])
     ],
     dependencies: [
-        .package(url: "https://github.com/cerihughes/provident", .upToNextMajor(from: "6.0.0")),
+        .package(url: "https://github.com/cerihughes/provident", .upToNextMajor(from: "7.0.0")),
         .package(url: "https://github.com/kif-framework/KIF", .upToNextMajor(from: "3.8.0"))
     ],
     targets: [

--- a/project.yml
+++ b/project.yml
@@ -28,7 +28,7 @@ options:
 packages:
   Provident:
     url: https://github.com/cerihughes/provident
-    majorVersion: 6.0.0
+    majorVersion: 7.0.0
   KIF:
     url: https://github.com/kif-framework/KIF
     majorVersion: 3.8.0


### PR DESCRIPTION
Also simplify some internal APIs by modelling the ContainerUI as `InternalContainer`